### PR TITLE
Disable build retency

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -1,11 +1,11 @@
 #!groovy
 
 /* Only keep the 10 most recent builds. */
-def projectProperties = [
+/*def projectProperties = [
     [$class: 'BuildDiscarderProperty',strategy: [$class: 'LogRotator', numToKeepStr: '5']],
 ]
 
-properties(projectProperties)
+properties(projectProperties)*/
 
 /* Declarative pipeline */
 pipeline {


### PR DESCRIPTION
Since molecule already removes containers and pipeline constantly uses one workspace, there is no need for jenkins-based jobs retency